### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@
  
  jdk:
    - oraclejdk8
+
+script: sbt test


### PR DESCRIPTION
The default command is `sbt ++$TRAVIS_SCALA_VERSION test`, which we
don't want here since there are two subprojects with different versions
of scala.
